### PR TITLE
Added NAXSI filter download and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In order to run this container you'll need docker installed.
 * `PROXY_SERVICE_PORT` - The port of the upstream host you want this service to proxy
 * `NAXSI_RULES_URL_CSV` - A CSV of [Naxsi](https://github.com/nbs-system/naxsi) rules to use. (Files must end in .conf to be loaded)
 * `NAXSI_RULES_MD5_CSV` - A CSV of md5 hashes for the files specified above
-* `NAXSI_USE_DEFAULT_RULES` - If set to "false" will delete the default rules file...
+* `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file...
 
 ### Ports
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ In order to run this container you'll need docker installed.
 
 * `PROXY_SERVICE_HOST` - The upstream host you want this service to proxy
 * `PROXY_SERVICE_PORT` - The port of the upstream host you want this service to proxy
+* `NAXSI_RULES_URL_CSV` - A CSV of [Naxsi](https://github.com/nbs-system/naxsi) rules to use. (Files must end in .conf to be loaded)
+* `NAXSI_RULES_MD5_CSV` - A CSV of md5 hashes for the files specified above
+* `NAXSI_USE_DEFAULT_RULES` - If set to "false" will delete the default rules file...
 
 ### Ports
 
@@ -37,6 +40,7 @@ This container exposes
 * `nginx.conf` is stored at `/usr/local/openresty/nginx/conf/nginx.conf`
 * `/etc/keys/crt` & `/etc/keys/key` - A certificate can be mounted here to make OpenResty use it. However a self 
   signed one is provided if they have not been mounted.
+* `/usr/local/openresty/naxsi/*.conf` - [Naxsi](https://github.com/nbs-system/naxsi) rules location in default nginx.conf.
   
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to run this container you'll need docker installed.
 
 * `PROXY_SERVICE_HOST` - The upstream host you want this service to proxy
 * `PROXY_SERVICE_PORT` - The port of the upstream host you want this service to proxy
-* `NAXSI_RULES_URL_CSV` - A CSV of [Naxsi](https://github.com/nbs-system/naxsi) rules to use. (Files must end in .conf to be loaded)
+* `NAXSI_RULES_URL_CSV` - A CSV of [Naxsi](https://github.com/nbs-system/naxsi) URL's of files to download and use. (Files must end in .conf to be loaded)
 * `NAXSI_RULES_MD5_CSV` - A CSV of md5 hashes for the files specified above
 * `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file...
 

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,10 @@ make
 make install
 cd ..
 
+# Install NAXSI default rules...
+mkdir -p /usr/local/openresty/naxsi/
+cp ./naxsi-master/naxsi_config/naxsi_core.rules  /usr/local/openresty/naxsi/
+
 cd luarocks-2.2.1
 ./configure --with-lua=/usr/local/openresty/luajit \
     --lua-suffix=jit-2.1.0-alpha \

--- a/go.sh
+++ b/go.sh
@@ -1,10 +1,42 @@
 #!/usr/bin/env bash
 
+set -e
+
+function download() {
+
+    file_url=$1
+    file_md5=$2
+    download_path=$3
+
+    file_path=${file_path}/$(basename ${file_url})
+    error=0
+
+    for i in {1..5}; do
+        if [ ${i} -gt 1 ]; then
+            echo "About to retry download for ${file_url}..."
+            sleep 1
+        fi
+        wget -q -O ${file_path} ${file_url}
+        md5=$(md5sum ${file_path} | cut -d' ' -f1)
+        if [ "${md5}" == "${file_md5}" ] ; then
+            echo "File downloaded & OK:${file_url}"
+            error=0
+            break
+        else
+            echo "Error: MD5 expecting '${file_md5}' but got '${md5}' for ${file_url}"
+            error=1
+        fi
+    done
+    return ${error}
+}
+
 # Resolve any variable names here:
 PROXY_HOST=$(eval "echo $PROXY_SERVICE_HOST")
 export PROXY_SERVICE_PORT=$(eval "echo $PROXY_SERVICE_PORT")
 echo "Looking up $PROXY_HOST"
 for i in 1..3 ; do
+
+    set +e
     # DO name resolution of any hostnames
 
     # Cope with Skydns round-robin DNS errors...
@@ -15,6 +47,7 @@ for i in 1..3 ; do
     else
         NAME_RESOLVE=BAD
     fi
+    set -e
 done
 
 # Detect default configuration...
@@ -31,6 +64,22 @@ if diff /container_default_ngx /tmp/nginx_new ; then
         exit 1
     fi
     echo "Proxying to : http://$PROXY_SERVICE_HOST:$PROXY_SERVICE_PORT"
+fi
+
+if [ "${NAXSI_RULES_URL_CSV}" != "" ]; then
+    if [ "${NAXSI_RULES_MD5_CSV}" == "" ]; then
+        echo "Error, must specify NAXSI_RULES_MD5_CSV if NAXSI_RULES_URL_CSV is specified"
+        exit 1
+    fi
+    IFS=',' read -a NAXSI_RULES_URL_ARRAY <<< "$NAXSI_RULES_URL_CSV"
+    IFS=',' read -a NAXSI_RULES_MD5_ARRAY <<< "$NAXSI_RULES_MD5_CSV"
+    if [ ${#NAXSI_RULES_URL_ARRAY[@]} -ne ${#NAXSI_RULES_MD5_ARRAY[@]} ]; then
+        echo "Must specify the same number of items in \$NAXSI_RULES_URL_CSV and \$NAXSI_RULES_MD5_CSV"
+        exit 1
+    fi
+    for i in "${!NAXSI_RULES_URL_ARRAY[@]}"; do
+        download ${NAXSI_RULES_URL_ARRAY[$i]} ${NAXSI_RULES_MD5_ARRAY[$i]} /usr/local/openresty/naxsi
+    done
 fi
 
 eval "/usr/local/openresty/nginx/sbin/nginx -g \"daemon off;\""

--- a/go.sh
+++ b/go.sh
@@ -8,7 +8,7 @@ function download() {
     file_md5=$2
     download_path=$3
 
-    file_path=${file_path}/$(basename ${file_url})
+    file_path=${download_path}/$(basename ${file_url})
     error=0
 
     for i in {1..5}; do
@@ -80,6 +80,10 @@ if [ "${NAXSI_RULES_URL_CSV}" != "" ]; then
     for i in "${!NAXSI_RULES_URL_ARRAY[@]}"; do
         download ${NAXSI_RULES_URL_ARRAY[$i]} ${NAXSI_RULES_MD5_ARRAY[$i]} /usr/local/openresty/naxsi
     done
+fi
+if [ "${NAXSI_USE_DEFAULT_RULES}" == "FALSE" ]; then
+    echo "Deleting core rules..."
+    rm -f /usr/local/openresty/naxsi/naxsi_core.rules
 fi
 
 eval "/usr/local/openresty/nginx/sbin/nginx -g \"daemon off;\""

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,8 @@ env PROXY_SERVICE_PORT;
 
 http {
 
+    include  /usr/local/openresty/naxsi/*.rules ;
+
     lua_package_path 'conf/?.lua;;';
 
     # Sample logging format that supports


### PR DESCRIPTION
Resolves issue #3.

Tested locally, downloads files or uses default rules. NB, the Drupal rules specified below will not load normally, but given as an example of a download!
```
$ docker run -e PROXY_SERVICE_HOST=google.com -e PROXY_SERVICE_PORT=80 -e NAXSI_RULES_URL_CSV=https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules -e NAXSI_RULES_MD5_CSV=3b3c24ed61683ab33d8441857c315432 -e NAXSI_USE_DEFAULT_RULES=FALSE -d -p 8443:443 nginx

$ docker logs sad_brahmagupta
Looking up google.com
Proxying to : http://216.58.208.78:80
File downloaded & OK:https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules
2015/10/01 11:04:02 [notice] 22#0: using the "epoll" event method
2015/10/01 11:04:02 [notice] 22#0: openresty/1.7.10.1
2015/10/01 11:04:02 [notice] 22#0: built by gcc 4.8.3 20140911 (Red Hat 4.8.3-9) (GCC)
2015/10/01 11:04:02 [notice] 22#0: OS: Linux 4.0.9-boot2docker
2015/10/01 11:04:02 [notice] 22#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2015/10/01 11:04:02 [notice] 22#0: start worker processes
2015/10/01 11:04:02 [notice] 22#0: start worker process 23
 192.168.99.1 - - [01/Oct/2015:11:04:18 +0000] "GET / HTTP/1.1" nginxId=14657358-d1f1-435e-c31c-3ec7082dec88 301 677 "-" "curl/7.43.0" "-"
2015/10/01 11:04:18 [info] 23#0: *1 client 192.168.99.1 closed keepalive connection
```

@PurpleBooth  @jon-shanks LGTM?