### PR TITLE
Working optional UUID and removal of NAXSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In order to run this container you'll need docker installed.
 * `NAXSI_RULES_MD5_CSV` - A CSV of md5 hashes for the files specified above
 * `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file...
 * `LOAD_BALANCER_CIDR` - Set to preserve client IP addresses. *Important*, to enable, see [Preserve Client IP](#preserve-client-ip).
+* `ENABLE_UUID_PARAM` - If set to "FALSE", will NOT add a UUID url parameter to all requests. Defaults will add this for easy tracking in logs.
 
 ### Ports
 

--- a/go.sh
+++ b/go.sh
@@ -83,9 +83,18 @@ if [ "${NAXSI_RULES_URL_CSV}" != "" ]; then
         download ${NAXSI_RULES_URL_ARRAY[$i]} ${NAXSI_RULES_MD5_ARRAY[$i]} /usr/local/openresty/naxsi/location
     done
 fi
+if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
+    echo "Auto UUID request parameter disabled."
+else
+    echo "Auto UUID request parameter enabled."
+fi
 if [ "${NAXSI_USE_DEFAULT_RULES}" == "FALSE" ]; then
     echo "Deleting core rules..."
     rm -f /usr/local/openresty/naxsi/naxsi_core.rules
+    rm -f /usr/local/openresty/naxsi/location/location.rules
+else
+    echo "Core NAXSI rules enabled @ /usr/local/openresty/naxsi/naxsi_core.rules"
+    echo "Core NAXSI location rules enabled @ /usr/local/openresty/naxsi/location/location.rules"
 fi
 if [ "${LOAD_BALANCER_CIDR}" != "" ]; then
     echo "Using proxy_protocol from '$LOAD_BALANCER_CIDR' (real client ip is forwarded correctly by loadbalancer)..."

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,7 @@ error_log /dev/stdout debug;
 
 env PROXY_SERVICE_HOST;
 env PROXY_SERVICE_PORT;
+env ENABLE_UUID_PARAM;
 
 http {
 
@@ -11,7 +12,7 @@ http {
 
     # Sample logging format that supports
     log_format levlogging '$real_client_ip_if_set$remote_addr - $remote_user [$time_local] '
-                          '"$request" nginxId=$uuid $status $bytes_sent '
+                          '"$request"$uuid_log_opt $status $bytes_sent '
                           '"$http_referer" "$http_user_agent" "$gzip_ratio"';
 
     access_log /dev/stdout levlogging;
@@ -45,13 +46,22 @@ http {
             ngx.var.proxy_address = proxy_address
         ';
 
+        set $uuid_log_opt '';
         # Example of generating unique ID for use in logs for passing onto applications
-        set_by_lua $uuid '
-            local socket = require("socket")
-            local uuid = require("uuid")
-            uuid.randomseed(socket.gettime()*10000)
-            return uuid()';
-        set $args $args&nginxId=$uuid;
+        set_by_lua $uuidopt '
+            if os.getenv("ENABLE_UUID_PARAM") == "FALSE" then
+                return "";
+            else
+                local socket = require("socket")
+                local uuid = require("uuid")
+                uuid.randomseed(socket.gettime()*10000)
+                local uuid_str = uuid()
+                ngx.var.uuidopt = uuid_str
+                ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
+                local uuid_opt = "&nginxId=" .. uuid_str
+                return uuid_opt
+            end ';
+        set $args $args$uuidopt;
 
         error_page 500 501 502 503 504 /50x.html;
         location /50x.html {


### PR DESCRIPTION
All tested locally with docker... @allandegnan @PurpleBooth @jon-shanks 

```
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443 -e 'ENABLE_UUID_PARAM=FALSE' nginx &
[1] 5126
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ Looking up google.com
Proxying to : http://216.58.208.78:80
Auto UUID request parameter disabled.
Core NAXSI rules enabled @ /usr/local/openresty/naxsi/naxsi_core.rules
Core NAXSI location rules enabled @ /usr/local/openresty/naxsi/location/location.rules
No $LOAD_BALANCER_CIDR set, using straight SSL (client ip will be from loadbalancer if used)...
2015/10/05 11:39:57 [notice] 18#0: using the "epoll" event method
2015/10/05 11:39:57 [notice] 18#0: openresty/1.7.10.1
2015/10/05 11:39:57 [notice] 18#0: built by gcc 4.8.3 20140911 (Red Hat 4.8.3-9) (GCC)
2015/10/05 11:39:57 [notice] 18#0: OS: Linux 4.0.9-boot2docker
2015/10/05 11:39:57 [notice] 18#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2015/10/05 11:39:57 [notice] 18#0: start worker processes
2015/10/05 11:39:57 [notice] 18#0: start worker process 19

LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ curl -v --insecure https://192.168.99.100:8443/
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 8443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: test
> GET / HTTP/1.1
> Host: 192.168.99.100:8443
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: openresty/1.7.10.1
< Date: Mon, 05 Oct 2015 11:40:07 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 223
< Connection: keep-alive
< Location: http://www.google.com:443/
< Expires: Wed, 04 Nov 2015 11:40:07 GMT
< Cache-Control: public, max-age=2592000
< X-XSS-Protection: 1; mode=block
< X-Frame-Options: SAMEORIGIN
<
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com:443/">here</A>.
</BODY></HTML>
* Connection #0 to host 192.168.99.100 left intact
192.168.99.1 - - [05/Oct/2015:11:40:07 +0000] "GET / HTTP/1.1" 301 587 "-" "curl/7.43.0" "-"
2015/10/05 11:40:07 [info] 19#0: *1 client 192.168.99.1 closed keepalive connection
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker stop nginx_thing

nginx_thing
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443  nginx &[2] 5130
[1]   Exit 137                docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443 -e 'ENABLE_UUID_PARAM=FALSE' nginx
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ Looking up google.com
Proxying to : http://216.58.208.78:80
Auto UUID request parameter enabled.
Core NAXSI rules enabled @ /usr/local/openresty/naxsi/naxsi_core.rules
Core NAXSI location rules enabled @ /usr/local/openresty/naxsi/location/location.rules
No $LOAD_BALANCER_CIDR set, using straight SSL (client ip will be from loadbalancer if used)...
2015/10/05 11:40:37 [notice] 18#0: using the "epoll" event method
2015/10/05 11:40:37 [notice] 18#0: openresty/1.7.10.1
2015/10/05 11:40:37 [notice] 18#0: built by gcc 4.8.3 20140911 (Red Hat 4.8.3-9) (GCC)
2015/10/05 11:40:37 [notice] 18#0: OS: Linux 4.0.9-boot2docker
2015/10/05 11:40:37 [notice] 18#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2015/10/05 11:40:37 [notice] 18#0: start worker processes
2015/10/05 11:40:37 [notice] 18#0: start worker process 19

LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ curl -v --insecure https://192.168.99.100:8443/
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 8443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: test
> GET / HTTP/1.1
> Host: 192.168.99.100:8443
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: openresty/1.7.10.1
< Date: Mon, 05 Oct 2015 11:40:42 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 268
< Connection: keep-alive
< Location: http://www.google.com:443/?nginxId=cb2190fd-f6e7-4fb2-cf10-b12e32a25bf0
< Expires: Wed, 04 Nov 2015 11:40:42 GMT
< Cache-Control: public, max-age=2592000
< X-XSS-Protection: 1; mode=block
< X-Frame-Options: SAMEORIGIN
<
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com:443/?nginxId=cb2190fd-f6e7-4fb2-cf10-b12e32a25bf0">here</A>.
</BODY></HTML>
* Connection #0 to host 192.168.99.100 left intact
192.168.99.1 - - [05/Oct/2015:11:40:42 +0000] "GET / HTTP/1.1" nginxId=cb2190fd-f6e7-4fb2-cf10-b12e32a25bf0 301 677 "-" "curl/7.43.0" "-"
2015/10/05 11:40:42 [info] 19#0: *1 client 192.168.99.1 closed keepalive connection
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker stop nginx_thing
nginx_thing
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443 -e 'NAXSI_USE_DEFAULT_RULES=FALSE' nginx &
[3] 5139
[2]   Exit 137                docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443 nginx
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ Looking up google.com
Proxying to : http://216.58.208.78:80
Auto UUID request parameter enabled.
Deleting core rules...
No $LOAD_BALANCER_CIDR set, using straight SSL (client ip will be from loadbalancer if used)...
2015/10/05 11:42:40 [notice] 20#0: using the "epoll" event method
2015/10/05 11:42:40 [notice] 20#0: openresty/1.7.10.1
2015/10/05 11:42:40 [notice] 20#0: built by gcc 4.8.3 20140911 (Red Hat 4.8.3-9) (GCC)
2015/10/05 11:42:40 [notice] 20#0: OS: Linux 4.0.9-boot2docker
2015/10/05 11:42:40 [notice] 20#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2015/10/05 11:42:40 [notice] 20#0: start worker processes
2015/10/05 11:42:40 [notice] 20#0: start worker process 21

LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ curl -v --insecure https://192.168.99.100:8443/
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 8443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: test
> GET / HTTP/1.1
> Host: 192.168.99.100:8443
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: openresty/1.7.10.1
< Date: Mon, 05 Oct 2015 11:42:45 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 268
< Connection: keep-alive
< Location: http://www.google.com:443/?nginxId=58164dea-14a4-4beb-cb49-485421b7a17c
< Expires: Wed, 04 Nov 2015 11:42:45 GMT
< Cache-Control: public, max-age=2592000
< X-XSS-Protection: 1; mode=block
< X-Frame-Options: SAMEORIGIN
<
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com:443/?nginxId=58164dea-14a4-4beb-cb49-485421b7a17c">here</A>.
</BODY></HTML>
* Connection #0 to host 192.168.99.100 left intact
192.168.99.1 - - [05/Oct/2015:11:42:45 +0000] "GET / HTTP/1.1" nginxId=58164dea-14a4-4beb-cb49-485421b7a17c 301 677 "-" "curl/7.43.0" "-"
2015/10/05 11:42:45 [info] 21#0: *1 client 192.168.99.1 closed keepalive connection
(reverse-i-search)`exec': kubectl exec -it checking-proxy-v10-08v06 cat /etc/keys/crt
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker exec -it nginx_thing bash
[root@a9d97ac08864 openresty]# ls naxsi/
location
[root@a9d97ac08864 openresty]# ls naxsi/location/
[root@a9d97ac08864 openresty]# exit
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker stop nginx_thing
nginx_thing
LEWISs-MacBook-More-Pro:docker-ngx-openresty lewis$ docker run --name nginx_thing --rm=true -e 'PROXY_SERVICE_HOST=google.com' -e 'PROXY_SERVICE_PORT=80' -p 8443:443  nginx &[4] 5146
[3]   Exit 137
```